### PR TITLE
roles/poudriere/tasks/main.yml: Install up-to-date jails

### DIFF
--- a/roles/poudriere/tasks/main.yml
+++ b/roles/poudriere/tasks/main.yml
@@ -33,10 +33,12 @@
 - name: Update Poudriere jails
   command: poudriere jail -u -q -j {{ item.name }}{{ item.architecture }}
   with_items:
-  - { architecture: 'amd64', version: '10.1-RELEASE', name: '101' }
-  - { architecture: 'i386', version: '10.1-RELEASE', name: '101' }
-  - { architecture: 'amd64', version: '9.3-RELEASE', name: '93' }
-  - { architecture: 'i386', version: '9.3-RELEASE', name: '93' }
+  - { architecture: 'amd64', version: '12.0-CURRENT', name: '120' }
+  - { architecture: 'i386', version: '12.0-CURRENT', name: '120' }
+  - { architecture: 'amd64', version: '11.0-RELEASE', name: '110' }
+  - { architecture: 'i386', version: '11.0-RELEASE', name: '110' }
+  - { architecture: 'amd64', version: '10.3-RELEASE', name: '103' }
+  - { architecture: 'i386', version: '10.3-RELEASE', name: '103' }
   register: update_jails
   ignore_errors: yes
   changed_when: '"No updates are available to install." not in update_jails.stdout'


### PR DESCRIPTION
Use 10.3-R, 11.0-R, and 12.0-C on amd64 and i386