### PR TITLE
roles/poudriere/templates/nginx.conf.j2: Use alias in package location

### DIFF
--- a/roles/poudriere/templates/nginx.conf.j2
+++ b/roles/poudriere/templates/nginx.conf.j2
@@ -67,8 +67,8 @@ http {
                 break;
         }
 
-    location {{ poudriere_zrootfs }} {
-            root   {{ poudriere_zrootfs }}/data/packages/;
+        location {{ poudriere_zrootfs }} {
+            alias {{ poudriere_zrootfs }}/data/packages/;
             autoindex on;
         }
     }


### PR DESCRIPTION
... instead of root. Using root appends the URL path, while alias does
not.